### PR TITLE
Update userdata.tpl to install docker-cli properly

### DIFF
--- a/13-a_provisioner/userdata.tpl
+++ b/13-a_provisioner/userdata.tpl
@@ -9,5 +9,5 @@ software-properties-common &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu


### PR DESCRIPTION
sudo sudo was causing failure in installation of docker cli and when someone follows along the tutorial they wont be able to see docker --version working for them as @derekm1215  shows in the video. This should fix that issue. 