### PR TITLE
Replace deprecated bash commands in userdata.tpl

### DIFF
--- a/12-userdata/userdata.tpl
+++ b/12-userdata/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/12-userdata/userdata.tpl
+++ b/12-userdata/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \

--- a/13-a_provisioner/userdata.tpl
+++ b/13-a_provisioner/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
 sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/13-a_provisioner/userdata.tpl
+++ b/13-a_provisioner/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \

--- a/14-variables/userdata.tpl
+++ b/14-variables/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/14-variables/userdata.tpl
+++ b/14-variables/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \

--- a/15-variable_precedence/userdata.tpl
+++ b/15-variable_precedence/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/15-variable_precedence/userdata.tpl
+++ b/15-variable_precedence/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \

--- a/16-conditional_expressions/userdata.tpl
+++ b/16-conditional_expressions/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/16-conditional_expressions/userdata.tpl
+++ b/16-conditional_expressions/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \

--- a/17-outputs/userdata.tpl
+++ b/17-outputs/userdata.tpl
@@ -6,8 +6,14 @@ ca-certificates \
 curl \
 gnupg-agent \
 software-properties-common &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - &&
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" &&
+sudo install -m 0755 -d /etc/apt/keyrings &&
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null &&
 sudo apt-get update -y &&
-sudo sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
+sudo apt-get install docker-ce docker-ce-cli containerd.io -y &&
 sudo usermod -aG docker ubuntu

--- a/17-outputs/userdata.tpl
+++ b/17-outputs/userdata.tpl
@@ -8,7 +8,7 @@ gnupg-agent \
 software-properties-common &&
 sudo install -m 0755 -d /etc/apt/keyrings &&
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg -y &&
+sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg &&
 sudo chmod a+r /etc/apt/keyrings/docker.gpg &&
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \


### PR DESCRIPTION
Solving this issue was good practice for what I suspect is something commonly encountered in devops, however I suspect that not all newbies would know where to start.

I updated all instances of userdata.tpl in this repo but it looks like at least one other repo/course ( [terraform-azure](https://github.com/morethancertified/terraform-azure) ) uses the same file.

Cheers